### PR TITLE
Add Sword Candyfloss Route

### DIFF
--- a/route.json
+++ b/route.json
@@ -1,0 +1,12 @@
+{
+  "title": "Any% (Candyfloss)", 
+  "author": [ 
+    {
+      "name": "gavinNBD", 
+      "link": "https://www.speedrun.com/user/gavinNBD"
+    }
+  ],
+  "game": "Sword", 
+  "generation": 8,
+  "version": "1.0.0"
+}

--- a/route.mdr
+++ b/route.mdr
@@ -1,0 +1,1724 @@
+:::tracker{species="Candyfloss" baseStats="[[60, 67, 85, 77, 75, 116]]" hpIV=15 attackIV=15 defenseIV=15 spAttackIV=15 spDefenseIV=15 speedIV=15 nature="Modest" type="Grass/Fairy" generation=8 directInput=true}
+:::
+
+# Pokemon Sword Any% Speedrun
+## Candyfloss Route
+
+**Source**: [Candyfloss Route by New_Amber](https://docs.google.com/document/d/1dG1esE6UjLx4MBeP2MBIV6Dtg89P_gFrCEMZ8TkPG-4/edit?tab=t.0)
+
+*Disclaimer*: These notes are designed to be **beginner-friendly**. See this [Google Doc](https://docs.google.com/document/d/1v9G92VbtP6vurq5DQ4j07kqJU7JyLnLFREnZqBUI6Uc/edit)  for more advanced notes and riskier strategies.
+
+:::card{theme=warning}
+**Before the run starts**
+- Set your console to the **15 April** and the time to **23:45** (11:45pm).
+- Make sure to have the game closed when setting the time.
+
+**Starting the run**
+- Choose your player (any).
+- Make your name a single character (any).
+- Timing starts after saying "Yes" to character options.
+- Mash A through the intro cutscene. *When Rose says "exhibition match", you can stop mashing.*
+:::
+
+## Postwick
+
+Once your character gets off the couch, open your menu (x) and go to Options (<). 
+- *The parenthesis indicates controller movement. For example, "(v>)" would mean "down 1 input, right 1 input".*
+
+:::card{theme=info}
+**Options**
+- Text Speed:			Fast	(>)
+- Battle Effects:	Off		(v>)
+- Battle Style:		Set		(v>)
+- Give Nicknames:	Don't Give	(vv>) 
+- Skip Movies:		On		(RR<)
+:::
+
+Confirm your options (mash A), then head to the far right end of your home.
+- Pick up your bag in your bedroom. Head back to the center of the house to exit.
+- Go outside and follow Hop into his house. 
+- After mashing through the dialogue with Hop's Mom, exit his house.
+- Backtrack to the main road, then head north to Route 1.
+
+Follow the path straight to Wedgehurst.
+- Mash through all of the dialogue and cutscenes until it's time to pick your starter.
+- Pick :info[**Scorbunny**]{color=red} (center option).
+- Continue mashing through dialogue until your first battle begins.
+
+:::::::trainer[Hop 1]
+  :::::pokemon[Wooloo]
+     - Tackle x3
+  :::::
+  :::::pokemon[Grookey]
+     - Ember x2
+  :::::
+:::::::
+
+### Slumbering Weald
+
+Walk back to the main road and get stopped by Hop.
+- After the dialogue, head past the open fence gate and into the Slumbering Weald.
+- Run left and be prepared for one encounter in each grass patch.
+	- "Run" from each encounter, then continue left.
+	- After the third encounter, follow the path north into the fog.
+- During the battle with ???, use Tackle until the battle ends.
+	- Mash through the dialogue until you are taken to the front of your home.
+- Enter your house to say goodbye to your mum, then exit.
+- Head back to Route 1 to find Hop.
+
+### Route 1
+
+After talking to Hop, take the right path through Route 1.
+- As you go through the grass, you'll want to :info[catch a Pokemon]{color=yellow}.
+	- **Wooloo** is the ideal catch, followed by Skwovet.
+	- Don't bother damaging the Pokemon. Just through PokeBalls (X, A).
+- Once your Pokemon is caught, continue along the main path into Wedgehurst.
+
+## Wedgehurst
+
+Once you enter Wedgehurst, head directly right to find Leon in front of Sonia's Lab.
+- Mash through all of dialogue until you regain control of your character. 
+- Exit the lab for a short dialogue (receive Potions).
+	- Head directly right and wrap around the bushes to find a :info[**Rare Candy**]{color=yellow}.
+- Walk left (back into the center of Wedgehurst) and approach Hop.
+	- Hop will take you into the PokeCenter.
+	- Once inside, choose "Of course not" (second option) when prompted.
+- Exit the PokeCenter immediately and head north to meet back up with Hop.
+
+### Route 2
+
+Continue following Hop as he runs ahead of you. 
+- On Route 2, stick to the main path and dodge wild Pokemon.
+- If Zigzagoons are in your path, you can whistle (press left stick) to freeze them.
+
+:::::::trainer[Youngster Jake]
+  :::::pokemon[Skwovet]
+     - Ember x4
+  :::::
+:::::::
+
+Continue along the main path.
+- When you see the second trainer (Lass), walk through the grass behind her to skip the battle.
+- Continue north along the main path to the next Youngster trainer and talk to him.
+
+:::::::trainer[Youngster Benjamin]
+  :::::pokemon[Blipbug]
+     - Ember x1 + Quick Attack
+  :::::
+  :::::pokemon[Nickit]
+     - Quick Attack x3
+  :::::
+:::::::
+
+After defeating the Youngster, continue north to meet up with Hop.
+- Mash through all of the dialogue. 
+- :info[**FREE HEAL**]{color=pink}
+- Exit Professor Magnolia's House and head south to find Hop.
+- Talk to Hop on the battle court to begin the next fight.
+
+:::::::trainer[Hop 2]
+  :::::pokemon[Wooloo]
+     - Ember x3
+  :::::
+  :::::pokemon[Grookey]
+     - Ember x2-3
+  :::::
+  :::::pokemon[Rookidee]
+     - Quick Attack x2-3
+     - *If Hop ever used Growl, use Ember here instead.*
+  :::::
+:::::::
+
+Mash through the dialogue again.
+- :info[**FREE HEAL**]{color=pink}
+- Once you regain control, exit Magnolia's House and head south to get stopped by Hop.
+- Follow Hop back to town, retracing your steps the same way you came.
+	- Watch out for the new Yamper and Chewtle in the middle of the road.
+- Once you re-enter Wedgehurst, follow Hop into the train station.
+- Mash through all of the dialogue. Once you have control, exit the train station.
+
+## Wild Area
+
+Once out of the station, head north for dialogue with Hop and Sonia.
+- When done talking to Sonia, walk north (passing by the Onix on your left) toward the grass patch to your upper-left (see image).
+![Vulpix Patch](https://raw.githubusercontent.com/gavinNBD/ranger-routes/main/shield-candyfloss/assets/wildarea-growlpatch1.png)
+- If the den behind to the left of that grass patch is active (see image), interact with it to collect :info[300 Watts]{color=yellow}. 
+![Wild Area Den](https://raw.githubusercontent.com/gavinNBD/ranger-routes/main/shield-candyfloss/assets/wildarea-beam.png)
+
+Go into the grass patch to find a wild Vulpix.
+- Run into the first Vulpix you see. If you're having trouble spotting them, whistle to attract them.
+
+:::::::trainer[Wild Encounter]
+  :::::pokemon[Vulpix]
+     - Tackle x1
+     - Throw PokeBalls until caught
+  :::::
+:::::::
+
+Once you've caught your Vulpix, head north of the grass patch you are currently in.
+- Walk a few steps until you see the static Diggersby pop into view.
+- Hit the HOME button on your controller, then select "Settings" (gear icon). 
+	- Scroll down to the last option and select "System".
+	- Scroll down to Date/Time and change your system date to **April 15**.
+	- Press OK, then HOME to return to the main Switch menu. Press A to re-enter Pokemon Shield.
+- Go back into the Vulpix grass patch, but be careful not to get too far away from the Diggersby. If you cross the black line (see image), the Diggersby will despawn.
+![Vulpix Patch Threshold](https://raw.githubusercontent.com/gavinNBD/ranger-routes/main/shield-candyfloss/assets/wildarea-growlpatch2.png)
+
+Run in circles in the grass until you see an "!" icon appear. 
+- Run into the "!" to trigger a random encounter.
+- If you find a Minccino, catch it by throwing PokeBalls until it's caught.
+- If you find anything other than Mincinno, Run.
+
+Once you've caught your Minccino, open your menu (X).
+- Select "Pokemon", then press "R" to enter the Pokemon Box.
+- Clear the tutorial box (B). Hover your cursor over Scorbunny.
+	- Move Scorbunny and your Route 1 catch into the far-right column of your box using the "Select" tool. (Y, A, v, A, <, A)
+	- Then move Mincinno into the upper-left square of your box using the "Swap" tool. (Y, A, >, A)
+- Close your box and options menu (mash B).
+
+Run into the Diggersby. If the Diggersby despawned, run into the Vespiquen in its place.
+- Use Leer until you are KO'd.
+- Mash A to be teleported to Motostoke. (This is called "deathwarping".)
+
+Once you regain control, head east then north toward the :info[**Fire Stone**]{color=yellow} location (see image below).
+- If the raid den by the Vulpix patch wasn't active, interact with three inactive dens along your path to the Fire Stone and collect the Watts from each of them.
+![Fire Stone Location](https://raw.githubusercontent.com/gavinNBD/ranger-routes/main/shield-candyfloss/assets/firestone.png)
+- After picking up the Fire Stone, run into the nearest grass patch.
+- Find a wild Pokemon (Koffing is ideal) to encounter and deathwarp back to Motostoke.
+
+After being transported, turn right and talk to the NPC dressed in white and black.
+- Talk to him and purchase the maximum amount of :info[**Quick Balls**]{color=yellow} (3 minimum).
+- Mash B to exit the conversation. Walk back toward the giant staircase.
+- Walk up the giant staircase to enter Motostoke.
+
+## Motostoke (First Visit)
+
+Walk straight forward until you are stopped by Sonia.
+- Mash through the dialogue in the PokeCenter.
+- Open your menu, the open your bag to use the **Fire Stone** on Vulpix.
+
+Exit your menu and talk to the Move Reminder (NPC on far left, next to Indeedee).
+- Select "Remember a move" (v, A)
+- Mash through dialogue (A, A)
+- Select Ninetales (<, A)
+
+:::card{theme=info}
+Move Reminder
+- Teach **Nasty Plot** (A) in Slot 4.
+- Teach **Extrasensory** (vvvv) in Slot 2.
+- Teach **Flamethrower** (vvvv) in Slot 1.
+:::
+
+Exit the Pokemon Center and talk to Sonia.
+- Head north until you are stopped by Leon.
+- Continue north onto the elevator.
+- Equip the :info[**Charcoal**]{color=yellow} now (unless it's already holding one).
+
+Enter the stadium (straight ahead of you) and talk to the front desk NPC.
+- Mash through dialogue until you're prompted to choose your jersey number: "1" (A, +). 
+- Exit the stadium and head southwest until the NPC stops your.
+- Follow them left to the Budew Drop Inn, then enter the building.
+
+### Budew Drop Inn
+
+After talking to Sonia, head north and talk to the crowd of Team Yell Grunts.
+
+:::::::trainer[Team Yell Grunt 1]
+  :::::pokemon[Zigzagoon]
+     - Flamethrower x1-2
+  :::::
+:::::::
+
+:::::::trainer[Team Yell Grunt 2]
+  :::::pokemon[Nickit]
+     - Flamethrower x1-2
+  :::::
+:::::::
+
+:info[**FREE HEAL**]{color=pink}
+
+:::::::trainer[Team Yell Grunt Duo]
+  :::::pokemon[Zigzagoon]
+     - Flamethrower x1-2
+  :::::
+  :::::pokemon[Nickit]
+     - Flamethrower x1-2
+  :::::
+:::::::
+
+Once the fights are over, talk to the receptionist (left) to rest for the night.
+- :info[**FREE HEAL**]{color=pink}
+- Exit the building in the morning and mash A to be transported to the stadium.
+
+### Motostoke Stadium
+
+Go inside the stadium and talk to the front desk, then mash through cutscenes.
+- Exit the stadium and mash through dialogue to receive the Flying Taxi. 
+- In the main menu, press "+" to open your map.
+- Move the cursor one spot left to select West (Upper) Motostoke.
+- Immediately run left to find Hop.
+
+:::::::trainer[Hop 3]
+  :::::pokemon[Wooloo]
+      - Nasty Plot x1, Flamethrower x1
+  :::::
+  :::::pokemon[Grookey]
+     - Flamethrower x1
+  :::::
+  :::::pokemon[Rookidee]
+     - Flamethrower x1
+  :::::
+:::::::
+
+### Route 3
+
+Continue walking left into Route 3, making sure to go behind the first Lass trainer on the route.
+- After passing the Lass, get ready for a tricky trainer skip.
+	- You want to slightly hug the left wall until you're in the grass (see gif).
+	- Alternatively, can wait until she looks to the right and then safely pass her.
+- If you run into a wild Pokemon, that's OK. It's better than being spotted by the trainer.
+![Route 3 Schoolgirl Skip](https://raw.githubusercontent.com/gavinNBD/ranger-routes/main/shield-candyfloss/assets/route3TrainerDodge.gif)
+
+:::::::dropdown{title="If you hit the Schoolgirl trainer, click here." theme="warning"}
+
+::::::trainer[Schoolgirl Hannah]
+  ::::pokemon[Pancham]
+     - Extrasensory x1-2
+  ::::
+::::::
+
+:::::::
+
+Continue north through the grass, staying far enough right to avoid the Schoolboy's line of vision.
+- Meet up with Sonia and mash through the dialogue.
+- :info[**FREE HEAL**]{color=pink}
+- Continue walking westward (left). After passing the grass patch with Rolycoly, watch out for the Postman trainer walking in a circle.
+- Pass the Postman and continue left to the next trainer.
+
+:::::::trainer[Schoolboy Peter]
+  :::::pokemon[Sizzlipede]
+     - Nasty Plot x1, Extrasensory x2
+  :::::
+  :::::pokemon[Dottler]
+     - Flamethrower x1
+  :::::
+:::::::
+
+Continue north along the path and enter Galar Mine.
+- *If you're low-ish on HP, talk to the NPC left of the mine entrance for a FREE HEAL.*
+
+### Galar Mine, No. 1
+
+Once in the mine, follow the main railcar tracks all the way through the mine.
+- Hug the right wall of the tracks to avoid being seen by trainers.
+- Once the track stop, continue north toward the wooden bridge.
+
+:::::::trainer[Worker Sandra]
+  :::::pokemon[Diglett]
+     - Nasty Plot x1, Flamethrower x1
+  :::::
+  :::::pokemon[Drilbur]
+     - Flamethrower x1
+  :::::
+:::::::
+
+:info[**HEAL 17+ HP**]{color=red}
+- Cross the wooden bridge and continue following the railcar tracks.
+- *Safety Pickup: The item ball on your left before talking to Bede is two Super Potions.*
+- At the end of the tracks, mash through dialogue with Bede.
+
+:::::::trainer[Bede 1]
+  :::::pokemon[Solosis]
+    - Nasty Plot x1,  Flamethrower x1
+  :::::
+  :::::pokemon[Gothita]
+    - Flamethrower x1
+  :::::
+  :::::pokemon[Hatenna]
+    - Flamethrower x1
+  :::::
+:::::::
+
+### Route 4
+
+Exit the mine and enter the first walled wheat field on your right. 
+- Head all the way to the right to pick up the hidden :info[**Rare Candy**]{color=yellow}. (see image)
+![Rare Candy Route 4](https://raw.githubusercontent.com/gavinNBD/ranger-routes/main/shield-candyfloss/assets/route4b.jpg)
+
+Walk north (don't get too close to Breeder trainer) out of the grass patch.
+- Follow the main road left and then north to Turffield. Mash through the Milo + Wooloo cutscene.
+
+## Turffield
+
+Continue north to talk to Hop. Follow Yamper to the left three times.
+- Talk to Sonia, then open your map (X, +, A, A) to fly back to Turffield.
+- Head north into the Turffield Stadium, then talk to the central gym attendant to start the Gym Challenge.
+
+:info[**FREE HEAL**]{color=pink}
+
+:::card{theme=info}
+Wooloo Herding Tips
+- **Don't get too close to the Wooloo.** You can "push" them from a distance and getting closer doesn't make them go any faster. Getting *too* close to them can cause them to scatter wildly.
+- **Use the walls.** Herding Wooloo along the walls will keep them mostly together. Once the Wooloo hit the slanted walls at the end of each section, they'll typically herd themselves in.
+- **Don't panic.** If some Wooloo get away from you, focus on getting your main horde to the goal. Then go back and scoop up the stragglers.
+:::
+
+**Wooloo Puzzles**
+- 1) Move in a zigzag pattern (left-up, right-up, left-up, right-up) to try and get all three Wooloo groups into a single cluster. Then push them straight to the goal zone.
+- 2) The Yamper on this route moves side-to-side. Head directly toward the Wooloo herd and push it straight into the goal. You want to put the Wooloo in the goal BEFORE fighting the trainer.
+
+:::::::trainer[Gym Trainer Samuel]
+  :::::pokemon[Gossifleur]
+    - Flamethrower x1
+  :::::
+:::::::
+
+**Wooloo Puzzles**
+- 3) Push the Wooloo herd down the left path all the way to the goal.
+- 4a) If you push forward through all the puzzles quickly, you can hit the Yamper cycle seen here:
+![Final Herding Challenge](https://raw.githubusercontent.com/gavinNBD/ranger-routes/main/shield-candyfloss/assets/WoolooHerding.gif)
+- 4b) Alternatively, you can wait until the right-side Yamper starts heading north, then SLOWLY push the Wooloo herd while you follow that Yamper. Try not get the herd too close to Yamper. 
+- Once the final puzzle is done, head up the stairs and down the tunnel.
+
+::::::trainer[Milo]
+ :::::pokemon[Gossifleur]
+    - Nasty Plot x3, Flamethrower x1
+ :::::
+ :::::pokemon[Eldegoss]
+    - Flamethrower x1
+ :::::
+::::::
+
+:info[**FREE HEAL**]{color=pink}
+
+### Route 5
+
+Exit the gym and fly to Turffield. 
+- Head right and follow the eastern path into Route 5.
+	- You can safely pass the camera crew double trainers since you only have one Pokemon in your party.
+- Keep walking right until you reach the Doctor NPC and Team Yell Grunts.
+
+:::::::trainer[Team Yell Grunt]
+  :::::pokemon[Zigzagoon]
+     - Flamethrower x1-2
+  :::::
+  :::::pokemon[Thievul]
+     - (Cheri Berry), Flamethrower x3+
+  :::::
+:::::::
+
+:::::::trainer[Team Yell Grunt]
+  :::::pokemon[Sableye]
+     - Nasty Plot x1, Flamethrower x1
+  :::::
+:::::::
+
+:info[**HEAL to FULL-ish**]{color=pink}
+
+Hop on the bike (+) and bike forward (right) to Hop.
+- *You'll want to use the bike at every opportunity you can going forward.*
+
+:::::::trainer[Hop 4]
+  :::::pokemon[Wooloo]
+    - Nasty Plot x1, Flamethrower x1
+  :::::
+  :::::pokemon[Corvisquire]
+    - Flamethrower x1
+  :::::
+  :::::pokemon[Thwackey]
+    - Flamethrower x1
+  :::::
+:::::::
+
+Make your way east along the main path (going above the Breeder and below the Office Worker).
+- The Office Worker walks left and right, stopping for a few seconds at either end. When she turns around to begin walking again, she can spot you.
+- Head into the tunnel and continue forward to trigger the Rose cutscene.
+
+## Hulbury (First Visit)
+
+After the Rose cutscene, open your menu:
+- Enter your Pokemon Box and **withdraw** Mincinno into Slot 2 of your party.
+- **Swap** Mincinno with Ninetales, then exit the menu.
+
+Bike south down the stairway into the Market Area.
+- Talk to the Backpacker NPC sitting at the left-most picnic table to **trade** Minccino for Candyfloss.
+
+Bike to the first market stall (blonde NPC on your right).
+- Talk to that NPC to buy a :info[**Rose Incense**]{color=yellow} (mash A).
+- Head to the next stall on the right (Breeder NPC). 
+	- Buy :info[**Energy Root (7)**]{color=yellow} 
+	- Buy :info[**Heal Powder (5)**]{color=yellow}.
+- Open your map and fly to the Wild Area spot south of Motostoke.
+
+### Wild Area (Second Visit)
+
+Follow the yellow line (see image below) toward Hammerlocke to find the :info[**Sun Stone**]{color=yellow}.
+![Sun Stone Location](https://raw.githubusercontent.com/gavinNBD/ranger-routes/main/shield-candyfloss/assets/SunStone.png)
+
+Once you have the Sun Stone, open your menu and go to the Bag:
+- Give the **Rose Incense** to Candyfloss.
+- Evolve Candyfloss with the **Sun Stone**.
+- Fly back to Hulbury (use Y on the map to jump cursor to Hulbury).
+
+### Motostoke (Pit Stop)
+
+Enter the Motostoke PokeCenter and visit the Move Reminder.
+- Teach **Moonblast** (vv) in Slot 1.
+- Teach **Hurricane** (vvv) in Slot 2.
+- Teach **Giga Drain** (vvvvvv) in Slot 3.
+- Teach **Energy Ball** (scroll down) in Slot 4.
+
+PokeMart:
+- Buy **X-SpAtk (42)**.
+- Buy **X-SpDef (2)**.
+
+Exit the PokeCenter and fly to Hulbury.
+
+## Hulbury (Return)
+
+Bike to the Lighthouse in the northeast corner of Hulbury. 
+- Talk to Nessa, then backtrack on your bike to the gym.
+- Talk to the attendant to begin the gym challenge.
+- Head right to the first trainer.
+
+:::::::trainer[Gym Trainer Julia]
+  :::::pokemon[Tympole]
+    - Moonblast x1
+  :::::
+:::::::
+
+:::card{theme=info}
+Button Puzzle #1
+- Press Red button.
+- Press Yellow button.
+- Press Red button again.
+- Proceed to the next trainer.
+:::
+
+:::::::trainer[Gym Trainer Heather]
+  :::::pokemon[Krabby]
+    - Moonblast x1
+  :::::
+  :::::pokemon[Corphish]
+    - Moonblast x1
+  :::::
+:::::::
+
+:::card{theme=info}
+Button Puzzle #2
+- Press Yellow button.
+- Press Red button.
+- Proceed toward the next trainer (do NOT fight).
+:::
+
+:::card{theme=info}
+Button Puzzle #3
+- Wait until the third trainer is looking left to pass her.
+- Go down the stairs and find the Yellow button. Press it.
+- Backtrack up the stairs while the trainer is looking left.
+- Press the Red button, the press the Blue button.
+- Head through the newly open path and up the staircase.
+:::
+
+:::::::trainer[Nessa 1]
+  :::::pokemon[Goldeen]
+    - Energy Ball x1
+  :::::
+  :::::pokemon[Arrokuda]
+    - Energy Ball x1
+  :::::
+  :::::pokemon[Drednaw]
+    - Energy Ball x1
+  :::::
+:::::::
+
+:info[**FREE HEAL**]{color=pink}
+- Exit the Hulbury Gym for a conversation with Oleana.
+- Open your Map and fly to Hulbury.
+- Bike to the right and enter the first building (restaurant).
+	- Walk toward Sonia and crew for a cutscene, then exit the restaurant.
+- Once Hop leaves, bike east along the main road into Galar Mine No. 2. 
+
+### Galar Mine, No. 2
+
+Upon entering the mine, hug the bottom wall to avoid wild Pokemon.
+- Continue forward to find Bede.
+
+:::::::trainer[Bede 2]
+  :::::pokemon[Solosis]
+    - X-SpAtk, Moonblast x1
+  :::::
+  :::::pokemon[Gothita]
+    - Moonblast x1
+  :::::
+  :::::pokemon[Hattena]
+    - Moonblast x1
+  :::::
+  :::::pokemon[Ponyta]
+    - Giga Drain x1
+  :::::
+:::::::
+
+Continue right to the next trainer (male Worker).
+- *As your progress, watch out for the small PokeBall-like objects on the ground. Those are wild Stunfisk. If you bike over them fast enough, they won't catch you.*
+
+:::::::trainer[Worker Francis]
+  :::::pokemon[Carkol]
+    - Energy Ball x2
+  :::::
+:::::::
+
+Continue south along the main path, however:
+- Watch out for female Worker trainer in the middle of the path.
+	- She stares right for a few seconds, then spins 180 degrees.
+  - If you are moving optimally, you can pass on her left side easily before she turns.
+- Continue south until you reach the Team Yell Grunts.
+
+:::::::trainer[Team Yell Grunt]
+  :::::pokemon[Thievul]
+     - Moonblast x1
+  :::::
+  :::::pokemon[Liepard]
+     - Energy Ball x1
+  :::::
+  :::::pokemon[Linoone]
+     - If Linoone = 100% HP: Moonblast x1
+     - If Linoone < 100% HP: Energy Ball x1
+  :::::
+  :::::pokemon[Pancham]
+     - Energy Ball x1
+  :::::
+:::::::
+
+:info[**FREE HEAL**]{color=pink}
+- After the post-fight dialogue, watch out for a Pokemon spawning immediately south of your starting position.
+- Continue south until the fork in the road (likely there will be a wild Pokemon in the fork). 
+  - Begin (slowly) taking the path leading southeast, then STOP and wait for the trainer to look away.
+	- Once he is looking right, bike past him to the southern route.
+- Continue until you reach Hop and Kabu. Mash through the cutscene.
+
+## Motostoke (Second Visit)
+
+Exit the mine and mash A through the dialogue with Hop.
+- Open your Map and fly to Lower Motostoke (Y to auto-cursor). 
+- Enter the PokeCenter and purchase :info[**X-SpAtk x21**]{color=yellow}.
+- Exit the PokeCenter and fly to Upper Motostoke. 
+- Bike right to the Budew Drop Inn and enter it. Mash through Marnie dialogue.
+
+:::::::trainer[Marnie 1]
+  :::::pokemon[Croagunk]
+    - Moonblast x1
+  :::::
+  :::::pokemon[Scraggy]
+    - Moonblast x1
+  :::::
+  :::::pokemon[Morpeko]
+    - Moonblast x1
+  :::::
+:::::::
+
+:info[**FREE HEAL**]{color=pink}
+- After the Marnie morning dialogue, exit the Budew Drop Inn. 
+- Bike right and enter Motostoke Stadium. Talk to the front desk to begin the gym challenge.
+- Enter the following grass patches in order and interact with the wild Pokemon.
+
+:::::::trainer[#1 - Top Grass]
+  :::::pokemon[Litwick]
+    - use Quick Ball
+  :::::
+:::::::
+
+:::::::trainer[#2 - Left Grass]
+  :::::pokemon[Vulpix]
+    - use Quick Ball
+  :::::
+:::::::
+
+:::::::trainer[#3 - Top Grass]
+  :::::pokemon[Litwick]
+    - use Quick Ball
+  :::::
+:::::::
+
+:::::::trainer[Kabu]
+  :::::pokemon[Ninetales]
+    - X-SpAtk x2, Max Airstream x1
+  :::::
+  :::::pokemon[Arcanine]
+    - Max Airstream x1
+  :::::
+  :::::pokemon[Centiskorch]
+    - Max Airstream x1
+  :::::
+:::::::
+
+:info[**FREE HEAL**]{color=pink}
+- **Swap** your Route 1 catch with Candyfloss in the Pokemon Box.
+- **Deposit** all of your other Pokemon in Column 1.
+- Exit Motostoke Stadium and mash through the multiple cutscenes.
+
+### Wild Area (Third Visit)
+
+Turn left (toward the path to the Fire Stone) and bike boost (B) into the Mudsdale in the middle of the road.
+- Use **Growl** (or Tail Whip/Leer/etc.) until you are KO'd by the Mudsdale.
+- When teleported to the Meet Up Spot, :info[**choose option 2**]{color=red} (Hammerlocke).
+  - This option comes up quickly so be careful not to mash through the dialogue.
+- After being deathwarped to outside Hammerlocke, turn around and enter the city.
+
+## Hammerlocke (First Visit)
+
+Walk forward to the group of NPCs to begin cutscenes.
+- Continue north into Hammerlocke Stadium for another cutscene, then exit the stadium.
+
+Bike into the PokeCenter (left of the stadium). Talk to the right-most clerk.
+- Buy: :info[**Guard Spec x2**]{color=yellow} (^^)
+- Buy: :info[**X-Accuracy x3**]{color=yellow} (^)
+- Buy: :info[**X-Speed x4**]{color=yellow} (^)
+
+Exit the PokeCenter and walk left to talk to Leon (choose Option 2 when prompted).
+- Bike eastward (opposite direction Leon ran) until you find the staircase.
+	- Go up the stairs and pick up the hidden :info[**Rare Candy**]{color=yellow} north of the PokeBall statue.
+- Open your Pokemon Box:
+  - **Swap** Candyfloss with your Route 1 catch (Slot 1).
+  - **Withdraw** Ninetales into Slot 2 of your party.
+  - Use **Rare Candy x3** on Candyfloss.
+- Fly to West Hammerlocke and bike west to meet up with Raihan.
+
+Hammerlocke Vault
+- Ascend every staircase until you find Sonia. You can bike up the outdoors staircases.
+- Mash through the cutscenes, then head back down the stairs to Raihan.
+- Exit the Vault and bike west until you the Team Yell Grunts on Route 6.
+- Ideally you should save your bike boost (B) until after you exit Hammerlocke.
+
+### Route 6
+
+Continue biking west until stopped by Team Yell Grunts.
+
+:::::::trainer[Team Yell Grunt]
+  :::::pokemon[Stunky]
+    - Moonblast x1
+  :::::
+  :::::pokemon[Linoone]
+    - Moonblast x1
+  :::::
+:::::::
+
+:::::::trainer[Team Yell Grunt]
+  :::::pokemon[Liepard]
+    - Energy Ball x1
+  :::::
+:::::::
+
+Continue west to the next trainer.
+
+:::::::trainer[Beauty Anita]
+  :::::pokemon[Clefairy]
+    - X-SpAtk, Giga Drain x1
+  :::::
+  :::::pokemon[Clefable]
+    - Energy Ball x1-2
+  :::::
+:::::::
+
+Continue west (dismounting bike recommended here) through the two grass patches.
+- *If you accidentally run into a wild Dugtrio and cannot escape, use Giga Drain to KO it.*
+- Climb up the ladder (right of the Doctor Duo), then climb up the next ladder in front of you.
+- Watch out for the Model trainer at the top of the cliff. She walks left and right, stopping to pause for a few seconds each time.
+  - Note: NPCs do not move while you are climbing ladders.
+- Bike past the Model and fight the next trainer on the route.
+
+:::::::trainer[Artist Duncan]
+  :::::pokemon[Koffing]
+     - Giga Drain x2
+  :::::
+  :::::pokemon[Sudowoodo]
+    - *If Koffing used Smokescreen, use an X-Acc here.*
+    - Moonblast x1, Giga Drain x1
+  :::::
+:::::::
+
+:::card{theme=warning}
+:info[**HEAL**]{color=red} to 45+ HP.
+:::
+
+## Stow-on-Side
+
+Continue along the main path until you enter Stow-on-Side.
+- Re-mount your bike and continue west to find Hop.
+
+:::::::trainer[Hop 5]
+  :::::pokemon[Cramorant]
+    - X-SpAtk, Energy Ball x1
+    - :info[Pluck does 36-42 (44)]{color=red}
+  :::::
+  :::::pokemon[Toxel]
+    - Energy Ball x1
+  :::::
+  :::::pokemon[Thwackey]
+    - Moonblast x1Boxing Glove
+  :::::
+  :::::pokemon[Silicobra]
+    - Moonblast x1
+  :::::
+:::::::
+
+Mash through dialogue, then bike north and enter the Gym. 
+- Talk to the attendant to begin the gym challenge.
+- :info[**FREE HEAL**]{color=pink}
+- Use either control stick to spin the teacups and navigate the puzzles.
+
+:::card{theme=info}
+Boxing Glove Puzzle #1
+- Avoid bonking against the walls as much as you can. 
+- Navigate to the bottom by following a zigzag pattern (right, then left, then right).
+:::
+
+:::::::trainer[Gym Trainer Ian]
+  :::::pokemon[Stufful]
+    - Moonblast x1
+  :::::
+  :::::pokemon[Bewear]
+    - Moonblast x1
+  :::::
+:::::::
+
+:::card{theme=info}
+Boxing Glove Puzzle #2
+- Start by spinning slightly left (but not all the way to the left wall).
+- Descend right of the first claw, then spin into the second claw to your lower-right.
+- Once pushed up, spin right again to hit the next claw.
+- Spin right again to take the far right path downward.
+- As you descend, spin left into the staircase-like path to reach the end.
+:::
+
+:::::::trainer[Gym Trainer Claire]
+  :::::pokemon[Farfetch'd]
+    - Moonblast x1
+  :::::
+:::::::
+
+:::card{theme=info}
+Boxing Glove Puzzle #3
+- Start by spinning slightly right, then left into the downward-facing claw.
+- After being pushed, slide left into the next claw. 
+- Spin left again and descend to the third claw.
+- After being pushed up, spin southeast (lower right) as far as you can.
+- Hit the next claw and get automatically pushed to the end of the puzzle.
+:::
+
+:::::::trainer[Gym Trainer Simon]
+  :::::pokemon[Hitmonlee]
+    - Moonblast x1-2
+  :::::
+  :::::pokemon[Hitmonchan]
+    - Moonblast x1-2
+  :::::
+:::::::
+
+Ascend the stairs and through the tunnel.
+- :info[**HEAL to FULL**]{color=red}
+
+:::::::trainer[Bea 1]
+  :::::pokemon[Hitmontop]
+    - X-SpAtk x2, (Heal if < 23 HP), Giga Drain x1
+  :::::
+  :::::pokemon[Pangoro]
+    - Energy Ball x1
+  :::::
+  :::::pokemon[Sirfetch'd]
+    - Energy Ball x1
+  :::::
+  :::::pokemon[Machamp]
+    - Moonblast x1
+  :::::
+:::::::
+
+:info[**FREE HEAL**]{color=pink}
+
+Exit the gym for a conversation with Sonia.
+- Take the western staircase all the way to the top to find Bede.
+- After the initial conversation, walk forward to begin the battle.
+
+:::::::trainer[Bede 3]
+  :::::pokemon[Duosion]
+    - X-SpAtk, Energy Ball x1
+    - If Light Screen: X-SpAtk again
+  :::::
+  :::::pokemon[Hattrem]
+    - Energy Ball x1
+  :::::
+  :::::pokemon[Gothorita]
+    - Energy Ball x1
+  :::::
+  :::::pokemon[Ponyta]
+    - Energy Ball x1
+  :::::
+:::::::
+
+:info[**FREE HEAL**]{color=pink}
+- Mash through the cutscenes until Sonia lets you go.
+- Bike down the staircase. At the bottom, bike all the way east into the forest.
+
+### Glimwood Tangle
+
+Head forward, then take your first right.
+- Follow the U-shaped path down, then up.
+- Slowly continue along the path and **STOP** as soon as you spot the double trainers.
+- :info[**DO NOT PASS**]{color=red} in front of the double trainers.
+- Take the path just to the left to go around them without being spotted.
+- Continue following the path north to reach Ballonlea.
+:::
+
+## Ballonlea
+
+Follow the main road to the far northern part of town and enter the gym.
+- After talking to Marnie, speak with the gym attendant to begin the gym challenge.
+- Once downstairs, head right to begin the trial. You will be asked questions mid-battle during this gym.
+
+:::::::trainer[Gym Trainer Annette]
+  :::::pokemon[Spritzee]
+    - Energy Ball x2
+    - *Quiz Answer: 1* (both answers correct; Atk/SpAtk boost)
+  :::::
+  :::::pokemon[Slurpuff]
+    - Energy Ball x1
+  :::::
+:::::::
+
+:::::::trainer[Gym Trainer Teresa]
+  :::::pokemon[Swirlix]
+    - X-SpAtk, Energy Ball x1
+    - *Quiz Answer: 1* (wrong but faster; Speed drop)
+  :::::
+  :::::pokemon[Aromatisse]
+    - Energy Ball x1
+  :::::
+:::::::
+
+:::::::trainer[Gym Trainer Theodora]
+  :::::pokemon[Morgrem]
+    - X-SpAtk, Giga Drain x1
+    - *Quiz Answer: 2* (correct; Def/SpDef boost)
+  :::::
+  :::::pokemon[Gardevoir]
+    - Energy Ball x1
+    	- *If confused, use Heal Powder first*
+    - :info[Mystical Fire does 36-42 (44)]{color=red}
+  :::::
+:::::::
+
+:::card{theme=info}
+Quiz Answers for Opal:
+- 2nd Option (the wizard)
+- 2nd Option (Purple)
+- 1st Option (16 years old)
+:::
+
+:::::::trainer[Opal]
+  :::::pokemon[Weezing]
+    - Turn 1: Swap to Ninetales
+    - Turn 2: Disable
+    - Turn 3: Swap to Candyfloss
+    - Turn 4+: X-SpAtk x2, Energy Ball x1
+  :::::
+  :::::pokemon[Togekiss]
+    - Moonblast x1-2
+  :::::
+  :::::pokemon[Mawile]
+    - Energy Ball x1
+  :::::
+  :::::pokemon[Alcremie]
+    - (Heal if < 37 HP), Energy Ball x1
+  :::::
+:::::::
+
+:info[**FREE HEAL**]{color=pink}
+
+## Hammerlocke (Second Visit)
+
+Exit the gym, then mash B when Opal talk to you outside of the stadium.
+- Fly to Central Hammerlocke (Y to auto-cursor).
+- Walk east to talk with Bede, then bike east to talk with Sonia.
+- Walk east to Hop once, then bike east to Hop again.
+
+### Route 7 
+
+:::::::trainer[Hop 6]
+  :::::pokemon[Trevenant]
+    - X-SpAtk x2, Moonblast x1
+	    - *If confused,* Heal Powder before attacking
+	 - :info[Shadow Claw does 25-28 (30)]{color=red}
+	 - :info[Shadow Claw crit does 37-43 (45)]{color=red}
+  :::::
+  :::::pokemon[Heatmor]
+    - Energy Ball x1
+  :::::
+  :::::pokemon[Snorlax]
+    - Energy Ball x1
+  :::::
+  :::::pokemon[Rillaboom]
+    - Moonblast x1
+  :::::
+  :::::pokemon[Boltund]
+    - Moonblast x1
+  :::::
+:::::::
+
+:info[**FREE HEAL**]{color=pink}
+- From the Hop battle location, bike right then north.
+- Hug the right-side wall to stay out of the Cabbie trainer's vision.
+- Continue north into the next route.
+
+### Route 8
+
+Follow the main path to the first ladder going downward (see image).
+- Climb down the ladder and fight the Doctor trainer.
+![Route 8](https://raw.githubusercontent.com/gavinNBD/ranger-routes/main/shield-candyfloss/assets/RT8.png)
+
+:::::::trainer[Doctor Joanna]
+  :::::pokemon[Roselia]
+    - Hurricane x1
+  :::::
+  :::::pokemon[Hattrem]
+    - Energy Ball x1-2
+  :::::
+:::::::
+
+Walk right to the next ladder and climb up it.
+- Walk right and pick up the :info[**X-Def (3)**]{color=yellow} inside the circle of grass.
+- Walk north along the path to the next ladder.
+- Walk north, then right to another ladder down into a pit.
+- Take the southern ladder out of the pit.
+- Continue north as far as you can, then head left.
+- After the Falinks crossing, grab the :info[**Pixie Plate**]{color=yellow} (see image) but do not equip it yet.
+![Pixie Plate](https://raw.githubusercontent.com/gavinNBD/ranger-routes/main/shield-candyfloss/assets/route8-pixieplate.png)
+
+Continue along the main path as it goes left, then curves right (don't go upstairs).
+- Pause before the DJ trainer and wait for him to look away from the next ladder.
+	- **BIKE** past the DJ when he's looking left and climb down the ladder.
+- Avoid the Falinks walking by, go up the staircase to the right and the following ladder.
+- Proceed north through the archway into the next part of the route.
+- Follow the path, hugging the left wall as you pass the Policeman to avoid his vision.
+
+## Circhester
+
+Follow the path leading straight ahead. 
+- Head north as far as you can until you are outside the gym.
+- Enter the gym (entrance is to your right) and talk to Hop.
+- Talk to the gym attendant to begin the gym challenge. 
+
+Gym Challenge
+- Follow the path outlined in the image below to navigate the pitfalls.
+![Gym Movement](https://raw.githubusercontent.com/gavinNBD/ranger-routes/main/shield-candyfloss/assets/gordieGymMovement.png)
+
+1st Trainer Skip
+- You can skip all the Gym Trainers, but the first one is tricky (see gif).
+- You want to have **both** of your trainer's feet touch the gray siding of the platform, but not get spotted by the trainer.
+![Gym Trainer Skip](https://raw.githubusercontent.com/gavinNBD/ranger-routes/main/shield-candyfloss/assets/IceGymSkip.gif)
+
+:::card{theme=warning}
+*Safety*: Save before Melony (x, R).
+:::
+
+:::::::trainer[Gordie]
+  :::::pokemon[Barbaracle]
+    - Energy Ball x1
+  :::::
+  :::::pokemon[Shuckle]
+    - Guard Spec, X-Def, X-SpAtk x2, Moonblast x1-2
+    - *If you are Level 45+ and Shuckle uses Power Split, set up to +6 SPA.*
+  :::::
+  :::::pokemon[Stonjourner]
+    - Giga Drain x1
+  :::::
+  :::::pokemon[Coalossal]
+    - Energy Ball x2
+  :::::
+:::::::
+
+:info[**FREE HEAL**]{color=pink}
+
+:::card{theme=warning}
+Equip the **Pixie Plate**.
+:::
+
+Exit the gym. 
+- *Safety*: Pick up the **X-SpAtk (2)** in the top-left corner of town (left of gym entrance).
+- Head down the left side of town to reach the restaurant (Bob's Your Uncle).
+- Enter the restaurant and head to Hop & Sonia. Mash through the cutscenes.
+- Exit the restaurant to face off versus Hop.
+- :info[**FREE HEAL**]{color=pink}
+
+:::::::trainer[Hop 7]
+  :::::pokemon[Dubwool]
+    - X-SpAtk x3, Giga Drain x1
+    - :info[Take Down does 34-40 (42)]{color=red}
+    - :info[Hail does 7]{color=red}
+  :::::
+  :::::pokemon[Corviknight]
+    - Moonblast x1
+  :::::
+  :::::pokemon[Snorlax]
+    - Moonblast x1
+  :::::
+  :::::pokemon[Rillaboom]
+    - Moonblast x1
+  :::::
+  :::::pokemon[Pincurchin]
+    - Giga Drain x1
+  :::::
+:::::::
+
+Follow the pathways due east until you're in front of the clothing store.
+- Head south to exit town.
+
+### Route 9
+
+Continue south until you pass the grass patch on your right.
+![Route 9 Path](https://raw.githubusercontent.com/gavinNBD/ranger-routes/main/shield-candyfloss/assets/RT9a.png)
+- Hug the right-side wall as you go downhill to avoid the Dancer trainer's vision.
+- Continue south until you hit the Team Yell grunts.
+
+:::::::trainer[Team Yell Grunt]
+  :::::pokemon[Linoone]
+    - Moonblast x1
+  :::::
+  :::::pokemon[Pangoro]
+    - Moonblast x1
+    - :info[Bullet Punch does ~40]{color=red} 
+    - :info[Hail does 7]{color=red}
+  :::::
+:::::::
+
+Once you receive the Water Bike upgrade, mount your bike.
+- Take the top-right path (see image).
+- Hug the left wall, then go **behind** the Fisher trainer on the shore. 
+- Continue south to the beach, avoiding Pokemon as best you can.
+![Route 9 Path](https://raw.githubusercontent.com/gavinNBD/ranger-routes/main/shield-candyfloss/assets/Route9.jpg)
+
+### Spikemuth Outskirts
+
+Pick up hidden **Max Elixir** on the beach in the middle of the rock triangle.
+- Continue south and approach the crowd to trigger the cutscene.
+- Walk through the southern grass patch and over to Marnie to battle her.
+
+:::::::trainer[Marnie 2]
+  :::::pokemon[Liepard]
+    - X-SpAtk, Giga Drain x1
+  :::::
+  :::::pokemon[Toxicroak]
+    - Moonblast x1
+  :::::
+  :::::pokemon[Scrafty]
+    - Moonblast x1
+    	- *Torment:* Hurricane x1
+    	- *Torment + Miss:* Moonblast x1
+    - If Scary Face: X-Speed
+    - If Swagger: Heal Powder
+  :::::
+  :::::pokemon[Morpeko]
+    - Giga Drain x1
+  :::::
+:::::::
+
+## Spikemuth
+
+Head inside Spikemuth and head right to begin the gym challenge.
+- Note: You can't ride your bike in here *during* the Gym Challenge.
+- After each battle, continue right to progress.
+
+:::::::trainer[Team Yell Grunt]
+  :::::pokemon[Linoone]
+    - Moonblast x1
+  :::::
+:::::::
+
+Walk right until you're stopped by the Mr. Mime wall.
+- Backtrack to fight the Team Yell Grunts.
+
+:::::::trainer[Team Yell Grunt]
+  :::::pokemon[Thievul]
+    - Moonblast x1
+  :::::
+:::::::
+
+Continue right.
+
+:::::::trainer[Team Yell Grunt]
+  :::::pokemon[Scrafty]
+    - Moonblast x1
+  :::::
+:::::::
+
+Continue right until you hit Mr. Mime, then turn around and backtrack.
+
+:::::::trainer[Team Yell Grunt]
+  :::::pokemon[Weavile]
+    - Moonblast x1
+    - :info[Ice Shard does 44-50 (54)]{color=red} 
+  :::::
+:::::::
+
+Continue right until you hit the barricade, then head north into the opening.
+
+:::::::trainer[Team Yell Double]
+  :::::pokemon[Drapion]
+    - Moonblast x1  | X-SpAtk on Candyfloss
+  :::::
+  :::::pokemon[Liepard]
+    - Giga Drain x1 | Max Elixir on Candyfloss
+  :::::
+:::::::
+
+After talking to Marnie, walk right past the crowd of people.
+- Continue walking that direction until the Piers cutscene is triggered.
+
+:::::::trainer[Piers]
+  :::::pokemon[Scrafty]
+    - X-SpAtk, Moonblast x1
+    - *If Sand Attack: use X-Acc*
+  :::::
+  :::::pokemon[Malamar]
+    - Moonblast x1
+  :::::
+  :::::pokemon[Obstagoon]
+    - Moonblast x1
+  :::::
+  :::::pokemon[Skuntank]
+    - Moonblast x1
+  :::::
+:::::::
+
+:info[**FREE HEAL**]{color=pink}
+- Mash through the various cutscenes until Leon runs away. You can mount your bike while the camera is panning from Leon back to you.
+- Get on your bike and re-enter Spikemuth immediately. 
+- Bike all the way back to Piers's stage and go to the lower-right corner.
+	- Pick up the :info[**Choice Specs**]{color=yellow}.
+- Bike all the way back through Spikemuth and exit town.
+- If you get blocked by Team Yell Grunts, dismount and walk around/through them. Then re-mount your bike.
+
+### Route 9 Tunnel
+
+Continue biking left through the Route 9 Tunnel.
+- Navigate the crowd (path: center lane, lower lane, then upper lane).
+- Exit the tunnel and continue forward to talk to Hop.
+- Swap the **Charcoal** onto Candyfloss (and the Pixie Plate onto Ninetales).
+	- *(X to swap items on the Party screen)*
+- Equip the **Choice Specs** on Candyfloss and fly to Central Hammerlocke.
+
+## Hammerlocke (Third Visit)
+
+Walk right to trigger a cutscene. 
+- Bike north into the Hammerlocke Stadium.
+- Continue north to the end of the hallway and talk to the gym attendant.
+
+:::::::trainer[Gym Trainer Sebastian]
+  :::::pokemon[Pelipper]
+    - Moonblast x1 | Extrasensory x1
+  :::::
+  :::::pokemon[Sliggoo]
+    - Moonblast x1 | Heal whatever took damage
+  :::::
+:::::::
+
+Talk to the next trainer to begin the next fight.
+
+:::::::trainer[Gym Trainer Camilla]
+  :::::pokemon[Turtonator]
+     - Moonblast x1 | X-SpAtk on Candyfloss
+  :::::
+  :::::pokemon[Ninetales]
+     - Moonblast x1 | X-SpAtk on Candyfloss
+    :::dropdown{title="Moonblast Disabled" theme="error"}
+     - X-SpAtk on Ninetales | Flamethrower x1
+     - X-SpAtk on Ninetales | Flamethrower x1
+    :::
+  :::::
+:::::::
+
+:::card{theme=warning}
+Swap the **Choice Specs** to Ninetales and **Pixie Plate** to Candyfloss.
+- If Candyfloss is burned, use a Burn Heal/Heal Powder.
+- Talk to the next trainer to begin the next fight.
+:::
+
+:::::::trainer[Gym Trainer Aria]
+  :::::pokemon[Hakamo-o]
+    - Moonblast x1
+  :::::
+  :::::pokemon[Abomasnow]
+    - Flamethrower x1
+  :::::
+:::::::
+
+:info[**HEAL > 69 HP**]{color=red}
+
+:::::::trainer[Raihan]
+  :::::pokemon[Gigalith]
+    - Energy Ball x1 | X-SpAtk on Candyfloss
+  :::::
+  :::::pokemon[Flygon]
+    - Giga Drain x1 | X-SpAtk on Candyfloss
+  :::::
+  :::::pokemon[Duraludon]
+    - Moonblast x1 | Heal Powder on Candyfloss
+  :::::
+  :::::pokemon[Sandaconda]
+    - Moonblast x1 | Heal Powder on Candyfloss
+  :::::
+:::::::
+
+:info[**FREE HEAL**]{color=pink}
+- Before exiting the gym, stop by the PokeMart clerk on your left.
+	- Purchase: :info[**Full Restore x11**]{color=yellow} (>^)
+	- *If you wiped to any trainer during the run, only buy x9 Full Restores.*
+- Exit the gym for cutscene with Professor Magnolia.
+
+:::card{theme=warning}
+Swap the **Choice Specs** back onto Candyfloss and **Pixie Plate** onto Ninetales.
+- Fly to East Hammerlocke and bike left to enter the train station.
+- Walk forward to trigger the Hop & Raihan cutscene.
+:::
+
+### Route 10
+
+Exit the train station and bike right.
+- Bike up the hill (hugging left wall) until you're stopped by the first trainer.
+![Route 10 Path](https://raw.githubusercontent.com/gavinNBD/ranger-routes/main/shield-candyfloss/assets/R10a.png)
+
+:::::::trainer[Doctor Graham]
+  :::::pokemon[Gardevoir]
+    - X-SpAtk, Giga Drain x1
+    - *If Calm Mind:* Moonblast x1
+  :::::
+:::::::
+
+Continue biking north up the hill. 
+- If you're moving quickly, you'll want to pass the Hiker on the left side. 
+- If you hesitated or moved slowly, you'll want to pause and see which way they're looking before passing. 
+
+Once you pass the Hiker, wait for the Office Worker to do his walking pattern.
+- He'll walk left, then turn around and look right. Pass behind him then.
+- Continue north, going counter-clockwise around the small boulder.
+	- *If you wiped to a trainer, pick up the **Comet Shards** hidden next to the small rock on your right.*
+- Fight the Postman trainer.
+![Route 10 Path 2](https://raw.githubusercontent.com/gavinNBD/ranger-routes/main/shield-candyfloss/assets/R10b.png)
+
+:::::::trainer[Postman Harper]
+  :::::pokemon[Pelipper]
+    - X-SpAtk, Moonblast x1
+    - :info[Air Slash = ~90 dmg]{color=red}
+  :::::
+  :::::pokemon[Noctowl]
+    - Moonblast x1
+  :::::
+:::::::
+
+Bike left (west) through the grass patch until you see the big hill north of you.
+- Head up the hill for the next fight (Hiker trainer).
+
+:::::::trainer[Hiker Donald]
+  :::::pokemon[Gigalith]
+    - Energy Ball x1
+    - *If hit by Air Slash: Giga Drain x1-2*
+  :::::
+  :::::pokemon[Rhydon]
+    - Energy Ball x1
+    - *If hit by Air Slash: Giga Drain x1*
+  :::::
+:::::::
+
+:info[**HEAL to 55+ HP**]{color=red}
+- Continue north for the next fight.
+- Be prepared to **STOP** after the next fight.
+
+:::::::trainer[Gentleman Glenn]
+  :::::pokemon[Darmanitan]
+    - Moonblast x1
+  :::::
+  :::::pokemon[Falinks]
+    - Moonblast x1
+    - :info[First Impression = ~32 dmg; Hail = 7 dmg]{color=red}
+  :::::
+  :::::pokemon[Grapploct]
+    - Moonblast x1
+  :::::
+:::::::
+
+:::card{theme=error}
+**STOP IMMEDIATELY**
+- **Deposit** Ninetales before proceeding to skip the double battle.
+- Proceed north over the hill and down into Wyndon.
+:::
+
+## Wyndon
+
+Talk to Hop in Wyndon, then open your menu.
+- **Withdraw** Ninetales back in your party.
+- Swap the **Pixie Plate** back onto Candyfloss.
+- :info[**HEAL to 33+ HP**]{color=red}
+- Fly to the northeast of Wyndon (X, +, up-right)
+
+### Wyndon Stadium (Challengers Cup)
+
+Bike into Wyndon Stadium and talk to the front desk.
+- Walk through the doors into the tunnel and onto the pitch.
+
+:::::::trainer[Marnie 3]
+  :::::pokemon[Liepard]
+    - X-SpAtk, Giga Drain x1
+  :::::
+  :::::pokemon[Toxicroak]
+    - Moonblast x1
+  :::::
+  :::::pokemon[Scrafty]
+    - Moonblast x1 
+	    - *Torment*: Hurricane x1
+    - *Scary Face*: X-Speed
+    - *Swagger*: Heal Powder or Full Restore
+  :::::
+  :::::pokemon[Morpeko]
+    - Energy Ball x1
+  :::::
+  :::::pokemon[Grimmsnarl]
+    - Moonblast x1
+  :::::
+:::::::
+	
+:info[**FREE HEAL**]{color=pink}
+
+:::card{theme=warning}
+Swap the **Choice Specs** from Ninetales onto Candyfloss.
+:::
+
+:::::::trainer[Hop 8]
+  :::::pokemon[Dubwool]
+    - X-SpAtk x2, Moonblast x1
+    - *Paralyzed:* Full Restore/Heal Powder
+  :::::
+  :::::pokemon[Pincurchin]
+    - Moonblast x1
+  :::::
+  :::::pokemon[Corviknight]
+    - Moonblast x1
+  :::::
+  :::::pokemon[Snorlax]
+    - Moonblast x1
+  :::::
+  :::::pokemon[Rillaboom]
+    - Moonblast x1
+  :::::
+:::::::
+
+:info[**FREE HEAL**]{color=pink}
+
+### Wyndon Plaza
+
+:::card{theme=warning}
+Swap **Ninetales** to the front (Y to swap).
+- Swap the **Choice Specs** onto Ninetales from Candyfloss.
+:::
+
+Leave the hotel (straight south) and talk to Piers.
+- After mashing through dialogue, say Yes to be teleported to the Plaza.
+- Find Macro Cosmo Eric in the three locations (see image).
+![Eric Locations](https://raw.githubusercontent.com/gavinNBD/ranger-routes/main/shield-candyfloss/assets/eric-locations.png)
+
+:::::::trainer[Macro Cosmos' Eric #1]
+  :::::pokemon[Meowth]
+    - Flamethrower x1
+    - *Speed Boost +2*
+  :::::
+  :::::pokemon[Durant]
+    - Flamethrower x1
+  :::::
+:::::::
+
+:::card{theme=warning}
+Bike west and go into the nearby PokeCenter to purchase **Calcium (max)**. 
+- Exit the PokeCenter and bike directly south to the next Eric location. 
+:::
+
+:::::::trainer[Macro Cosmos' Eric #2]
+  :::::pokemon[Mawile]
+    - Flamethrower x1
+    - *Defenses Boost +2*
+  :::::
+  :::::pokemon[Excadrill]
+    - Flamethrower x1
+  :::::
+:::::::
+
+Bike left and talk to the telephone booth.
+
+:::::::trainer[Macro Cosmos' Eric #3]
+  :::::pokemon[Ferroseed]
+    - Flamethrower x1
+    - *Offenses Boost +2*
+  :::::
+  :::::pokemon[Steelix]
+    - Flamethrower x1
+  :::::
+:::::::
+
+### Rose Tower
+
+Bike north into Rose Tower.
+
+:::::::trainer[Macro Cosmos' Elijah]
+  :::::pokemon[Durant]
+    - Flamethrower x1
+  :::::
+:::::::
+
+Mash through dialogue, then walk into the elevator.
+
+:::::::trainer[Macro Cosmos' Double]
+  :::::pokemon[Cufant]
+    - Flamethrower x1
+  :::::
+  :::::pokemon[Bronzong]
+    - Flamethrower x1
+  :::::
+:::::::
+
+:info[**FREE HEAL**]{color=pink}
+
+:::::::trainer[Macro Cosmos' Double]
+  :::::pokemon[Klang]
+    - Flamethrower x1
+  :::::
+  :::::pokemon[Mawile]
+    - Flamethrower x1
+  :::::
+:::::::
+
+:info[**FREE HEAL**]{color=pink}
+
+:::::::trainer[Macro Cosmos' Double]
+  :::::pokemon[Stunfisk]
+    - Flamethrower x1-2
+    - *If you don't OHKO, let Hop finish it off.*
+  :::::
+  :::::pokemon[Steelix]
+    - Flamethrower x1
+  :::::
+:::::::
+
+:info[**FREE HEAL**]{color=pink}
+
+:::::::trainer[Oleana]
+  :::::pokemon[Froslass]
+    - Flamethrower x1-2
+  :::::
+  :::::pokemon[Milotic]
+    - *swap to Candyfloss*
+    - X-SpAtk x3, X-Acc, Hurricane x1
+    - :info[Surf does 27-32 (33)]{color=red} 
+  :::::
+  :::::pokemon[Salazzle]
+    - Hurricane x1
+  :::::
+  :::::pokemon[Tsareena]
+    - Hurricane x1
+  :::::
+  :::::pokemon[Garbodor]
+    - Hurricane x1
+  :::::
+:::::::
+
+:info[**FREE HEAL**]{color=pink}
+
+### Wyndon Stadium (Leaders Cup)
+
+:::card{theme=warning}
+Swap **Candyfloss** back to Slot 1.
+- Use all of your **Calcium** on Candyfloss.
+- Equip the **Charcoal** on Ninetales
+- Equip the **Choice Specs** on Candyfloss.
+- Mash A to fast travel, then head inside stadium.
+- Talk to the front desk, then walk onto the pitch.
+:::
+
+:::::::trainer[Bede 4]
+  :::::pokemon[Mawile]
+    - X-SpAtk, Moonblast x1
+  :::::
+  :::::pokemon[Gardevoir]
+    - Moonblast x1
+  :::::
+  :::::pokemon[Rapidash]
+    - Moonblast x1
+  :::::
+  :::::pokemon[Hatterene]
+    - Moonblast x1
+  :::::
+:::::::
+
+:info[**FREE HEAL**]{color=pink}
+- Walk back onto the pitch.
+
+:::::::trainer[Nessa 2]
+  :::::pokemon[Golisopod]
+    - X-SpAtk, X Speed, Energy Ball x1
+  :::::
+  :::::pokemon[Pelipper]
+    - Energy Ball x1
+  :::::
+  :::::pokemon[Seaking]
+    - Energy Ball x1
+  :::::
+  :::::pokemon[Barraskewda]
+    - Energy Ball x1
+  :::::
+  :::::pokemon[Drednaw]
+    - Energy Ball x1
+  :::::
+:::::::
+
+:info[**FREE HEAL**]{color=pink}
+- Walk back onto the pitch.
+
+:::::::trainer[Bea 2]
+  :::::pokemon[Hawlucha]
+    - Moonblast x1
+  :::::
+  :::::pokemon[Grapploct]
+    - X-SpAtk, Moonblast x1
+  :::::
+  :::::pokemon[Sirfetch'd]
+    - Moonblast x1
+  :::::
+  :::::pokemon[Falinks]
+    - Moonblast x1
+  :::::
+  :::::pokemon[Machamp]
+    - Moonblast x1
+  :::::
+:::::::
+
+:info[**FREE HEAL**]{color=pink}
+- Walk back onto the pitch.
+
+:::::::trainer[Raihan 2]
+  :::::pokemon[Torkoal]
+    - X-SpAtk, Moonblast x1
+    - *If Yawn Turn 1: X-SpDef, Full Restore*
+  :::::
+  :::::pokemon[Turtonator]
+    - Moonblast x1
+  :::::
+  :::::pokemon[Goodra]
+    - Moonblast x1
+  :::::
+  :::::pokemon[Flygon]
+    - Moonblast x1
+  :::::
+  :::::pokemon[Duraludon]
+    - Moonblast x1
+  :::::
+:::::::
+
+Run onto the pitch.
+
+### Slumbering Weald (Second Visit)
+
+Make your way through the Slumbering Weald (see gif).
+- *This gif starts after passing the first three grass patches and heading north.*
+![Slumbering Weald Movement](https://raw.githubusercontent.com/Corvimae/ranger-Routes/main/drifblim-alt-main-sword/assets/slumberingWealdMovement.gif)
+- *Source: wsopboy91's 4:07:06 run*
+- As a general guide, you'll want to take the left-most paths, with the exception that you do NOT want to go underneath the broken tree.
+
+After talking to Sonia, continue forward on your bike.
+- Bike north again to Hop and the Sword/Shield.
+- Pick up the Sword, then talk to Hop again to leave the forest.
+
+:::card{theme=warning}
+Swap **Ninetales** back into Slot 1.
+:::
+
+Bike into the Hammerlocke Gym and talk to Oleana.
+- Ride the elevator on your right.
+- Walk left, then north toward the large room with Rose.
+- Mash B when first talking to Rose to choose Option 2 in the conversation.
+
+### Hammerlocke (Fourth Visit)
+
+:::::::trainer[Rose]
+  :::::pokemon[Escavalier]
+    - Flamethrower x1
+  :::::
+  :::::pokemon[Klinklang]
+    - X-Def, Nasty Plot x2, Flamethrower x1
+  :::::
+  :::::pokemon[Ferrothorn]
+    - Flamethrower x1
+  :::::
+  :::::pokemon[Perrserker]
+    - Flamethrower x1
+  :::::
+  :::::pokemon[Copperajah]
+    - Flamethrower x1
+  :::::
+:::::::
+
+:::card{theme=warning}
+Swap **Candyfloss** into Slot 1.
+- :info[**HEAL to FULL**]{color=red} both Pokemon.
+:::
+
+Go southwest from the Rose fight to find Hop.
+- Talk to Hop to ride the elevator up.
+- Walk up the steps to initiate the cutscene.
+
+:::::::trainer[Eternatus 1]
+  :::::pokemon[Base Form]
+    - Moonblast x2-3
+    - *If Eternatus KOs Candyfloss:* Max Revive with Ninetales, then spam Extreme Speed.
+  :::::
+:::::::
+
+:info[**FREE HEAL**]{color=pink}
+- Mash A through the first D-Max Eternatus "fight" sequence.
+- Wait for the legendary dogs to arrive (1:20 cutscene).
+
+:::::::trainer[Eternatus 2]
+  :::::pokemon[Eternamax Form]
+    - Guard Spec, Moonblast x2-3
+    - *If Eternatus KOs Candyfloss:* Max Revive with Ninetales, then spam Leer.
+  :::::
+:::::::
+
+### Wyndon Stadium (Championship Match)
+
+Go outside the hotel and open the menu:
+- Swap **Charcoal** from Ninetales onto Eternatus.
+- **Deposit** everything except Eternatus.
+	- *Optional:* Check if Eternatus's Speed is 194+.
+- Fly to the northeast PokeCenter and enter the Stadium.
+- Talk to the front desk, then run onto the pitch.
+
+:::::::trainer[Leon]
+  :::::pokemon[Aegislash]
+    - X-SpAtk, X-Speed, Flamethrower x1
+    - *If Eternatus has 194+ Speed, you can skip the X-Speed.*
+    - *If Aegislash drops your SpDef on Turn 1, use your X-SpDef.*
+  :::::
+  :::::pokemon[Haxorus]
+    - Dynamax Cannon x1
+  :::::
+  :::::pokemon[Mr. Rime]
+    - Flamethrower x1
+  :::::
+  :::::pokemon[Dragapult]
+    - Dynamax Cannon x1
+  :::::
+  :::::pokemon[Inteleon]
+    - Dynamax Cannon x1
+  :::::
+  :::::pokemon[Charizard]
+    - Dynamax Cannon x1
+  :::::
+:::::::
+
+Timing ends when the screen finishes fading to black, after Leon tosses his hat.


### PR DESCRIPTION
First upload of Sword Candyfloss

**Please include the route in the name of the PR (for example, `AS Any% - Fix Archie 2`)**

## Route ID (for example, `alpha-sapphire-any-percent`)

sword-candyfloss

## Summary of changes

Adapted existing Shield route to Sword version and uploaded as separate folder

## Checklist
* [X] I have tested these changes and Ranger does not display any errors or warnings.
* [X] All image embeds have relative paths.
* [X] The route contains all fights required for the category.
